### PR TITLE
[FEAT] plan crud 작성 / 의존성 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/controller/PlanController.java
@@ -1,0 +1,54 @@
+package com.neroplan.neroplan.domain.plan.controller;
+
+import com.neroplan.neroplan.domain.plan.dto.CreatePlanRequestDto;
+import com.neroplan.neroplan.domain.plan.dto.CreatePlanResponseDto;
+import com.neroplan.neroplan.domain.plan.dto.GetPlanResponseDto;
+import com.neroplan.neroplan.domain.plan.dto.UpdatePlanRequestDto;
+import com.neroplan.neroplan.domain.plan.service.PlanService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.neroplan.neroplan.domain.plan.repository.PlanRepository;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("")
+@RequiredArgsConstructor
+public class PlanController {
+    private final PlanService planService;
+
+    // 1. 플랜 생성
+    @PostMapping
+    public ResponseEntity<CreatePlanResponseDto> createPlan(@RequestBody CreatePlanRequestDto requestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(requestDto));
+    }
+
+    // 2. 플랜별 단건 조회
+    @GetMapping("/{planId}")
+    public ResponseEntity<GetPlanResponseDto> getPlan(@PathVariable Long planId) {
+        return ResponseEntity.ok(planService.getPlan(planId));
+    }
+
+    // 3. 유저별 전체 조회
+    @GetMapping
+    public ResponseEntity<List<GetPlanResponseDto>> getPlansByUser(@RequestParam Long userId) {
+        return ResponseEntity.ok(planService.getPlansByUserId(userId));
+    }
+
+    // 4. 플랜 수정
+    @PatchMapping("/{planId}")
+    public ResponseEntity<GetPlanResponseDto> updatePlan(
+            @PathVariable Long planId,
+            @RequestBody UpdatePlanRequestDto requestDto) {
+        return ResponseEntity.ok(planService.updatePlan(planId, requestDto));
+    }
+
+    // 5. 플랜 삭제
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<Void> deletePlan(@PathVariable Long planId) {
+        planService.deletePlan(planId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/CreatePlanRequestDto.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/CreatePlanRequestDto.java
@@ -1,0 +1,22 @@
+package com.neroplan.neroplan.domain.plan.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreatePlanRequestDto {
+
+    @NotBlank(message = "계획 내용은 필수입니다.")
+    private String content;
+
+    @NotNull(message = "우선순위는 필수입니다.")
+    private Long priority;
+
+    // userId의 경우 서버가 토큰에서 추출
+    // categoryId의 경우 서버가 AI를 통해 결정
+    // private Long userId;
+    // private Long categoryId;
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/CreatePlanResponseDto.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/CreatePlanResponseDto.java
@@ -1,0 +1,34 @@
+package com.neroplan.neroplan.domain.plan.dto;
+
+import com.neroplan.neroplan.domain.plan.entity.Plan;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CreatePlanResponseDto {
+
+    private Long planId;
+    private String content;
+    private Long priority;
+    private LocalDateTime createdTime;
+    private Long userId;
+    private Long categoryId;
+
+
+    public static CreatePlanResponseDto from(Plan plan) {
+        return CreatePlanResponseDto.builder()
+                .planId(plan.getPlanId())
+                .content(plan.getContent())
+                .createdTime(plan.getCreatedTime())
+                .priority(plan.getPriority())
+                .userId(plan.getUserId())
+                .categoryId(plan.getCategoryId())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/GetPlanResponseDto.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/GetPlanResponseDto.java
@@ -1,0 +1,34 @@
+package com.neroplan.neroplan.domain.plan.dto;
+
+import com.neroplan.neroplan.domain.plan.entity.Plan;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class GetPlanResponseDto {
+
+    private Long planId;
+    private String content;
+    private LocalDateTime createdTime;
+    private Long priority;
+    private Long userId;
+    private Long categoryId;
+
+
+    public static GetPlanResponseDto from(Plan plan) {
+        return GetPlanResponseDto.builder()
+                .planId(plan.getPlanId())
+                .content(plan.getContent())
+                .createdTime(plan.getCreatedTime())
+                .priority(plan.getPriority())
+                .userId(plan.getUserId())
+                .categoryId(plan.getCategoryId())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/UpdatePlanRequestDto.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/dto/UpdatePlanRequestDto.java
@@ -1,0 +1,13 @@
+package com.neroplan.neroplan.domain.plan.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UpdatePlanRequestDto {
+
+    private String content;
+    private Long priority;
+
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/entity/Plan.java
@@ -1,0 +1,47 @@
+package com.neroplan.neroplan.domain.plan.entity;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Plan {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long planId;
+
+    @NotNull
+    private String content;
+
+    @NotNull
+    private Long priority;
+
+    @NotNull
+    private LocalDateTime createdTime;
+
+    @NotNull
+//    user 객체 생성 시 수정
+//    @ManyToOne
+//    @JoinColumn(name = "user_id")
+//    private User user;
+    private Long userId;
+
+    @NotNull
+//    category 객체 생성 시 수정
+//    @ManyToOne
+//    @JoinColumn(name = "category_id")
+//    private Category category;
+    private Long categoryId;
+
+    public void updatePlan(String content, Long priority) {
+        if (content != null) this.content = content;
+        if (priority != null) this.priority = priority;
+    }
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/entity/PlanDetail.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/entity/PlanDetail.java
@@ -1,0 +1,45 @@
+package com.neroplan.neroplan.domain.plan.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlanDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long planDetailId;
+
+    private Double successRate;
+
+    private Timestamp recommendedTime;
+
+    private String priorityReason;
+
+    private Boolean isBiased;
+
+    private String biasedReason;
+
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="plan_id")
+    private Plan plan;
+
+    // 필요한 경우 update 메서드 추가
+    public void updatePlanDetail(Double successRate, Timestamp recommendedTime,
+                                 String priorityReason, Boolean isBiased,
+                                 String biasedReason) {
+        if (successRate != null) this.successRate = successRate;
+        if (recommendedTime != null) this.recommendedTime = recommendedTime;
+        if (priorityReason != null) this.priorityReason = priorityReason;
+        if (isBiased != null) this.isBiased = isBiased;
+        if (biasedReason != null) this.biasedReason = biasedReason;
+    }
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,17 @@
+package com.neroplan.neroplan.domain.plan.repository;
+
+import com.neroplan.neroplan.domain.plan.dto.CreatePlanRequestDto;
+import com.neroplan.neroplan.domain.plan.dto.CreatePlanResponseDto;
+import com.neroplan.neroplan.domain.plan.dto.GetPlanResponseDto;
+import com.neroplan.neroplan.domain.plan.dto.UpdatePlanRequestDto;
+import com.neroplan.neroplan.domain.plan.entity.Plan;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+
+public interface PlanRepository extends JpaRepository<Plan, Long>{
+    List<Plan> findByUserId(Long userId);
+
+}

--- a/backend/src/main/java/com/neroplan/neroplan/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/neroplan/neroplan/domain/plan/service/PlanService.java
@@ -1,0 +1,74 @@
+package com.neroplan.neroplan.domain.plan.service;
+
+import com.neroplan.neroplan.domain.plan.dto.GetPlanResponseDto;
+import com.neroplan.neroplan.domain.plan.dto.UpdatePlanRequestDto;
+import com.neroplan.neroplan.domain.plan.entity.Plan;
+import com.neroplan.neroplan.domain.plan.repository.PlanRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.neroplan.neroplan.domain.plan.dto.CreatePlanRequestDto;
+import com.neroplan.neroplan.domain.plan.dto.CreatePlanResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    // 1. 플랜 생성
+    @Transactional
+    public CreatePlanResponseDto createPlan(CreatePlanRequestDto requestDto) {
+        Plan plan = Plan.builder()
+                .content(requestDto.getContent())
+                .priority(requestDto.getPriority())
+                .build();
+
+        Plan savedPlan = planRepository.save(plan);
+
+        return CreatePlanResponseDto.from(savedPlan);
+    }
+
+    // 2. 플랜 id 별 단건 조회
+    @Transactional(readOnly = true)
+    public GetPlanResponseDto getPlan(Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계획입니다. 플랜아이디 : " + planId));
+        return GetPlanResponseDto.from(plan);
+    }
+
+    // 3. 유저별 플랜 전체 조회
+    @Transactional(readOnly = true)
+    public List<GetPlanResponseDto> getPlansByUserId(Long userId) {
+        return planRepository.findByUserId(userId).stream()
+                .map(plan -> GetPlanResponseDto.from(plan))
+                .toList();
+    }
+
+    // 4. 플랜 수정
+    @Transactional
+    public GetPlanResponseDto updatePlan(Long planId, UpdatePlanRequestDto requestDto) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계획입니다. 플랜아이디 : " + planId));
+        plan.updatePlan(requestDto.getContent(), requestDto.getPriority());
+        return GetPlanResponseDto.from(plan);
+    }
+
+    // 5. 플랜 삭제
+    @Transactional
+    public void deletePlan(Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계획입니다. 플랜아이디 : " + planId));
+        planRepository.delete(plan);
+    }
+}
+
+


### PR DESCRIPTION
---
name: 오지현
about: plan / setup
title: plan crud 작성 / build.gradle에 의존성 추가
labels: feat
assignees: 오지현
---

## 📌 작업 내용
- plan crud를 작성합니다.
- plan entity와 dto를 작성합니다.
- plan controller, service, repository를 작성합니다.
- build.gradle에 의존성을 추가합니다.

## 🔍 주요 변경 사항
- plan 폴더 추가
- build.gradle 의존성 추가

## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [x] 주요 시나리오에 대한 테스트 완료
- [x] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #5 

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [x] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [x] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [x] 불필요한 디버깅 코드, 로그 제거
- [x] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- ### 컨트롤러에 엔드포인트 없어서 테스트가 안됩니다.
