### PR TITLE
[FIX]  postgresql 설정을 추가하고 DB를 설정하여 빌드 오류를 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	runtimeOnly 'org.postgresql:postgresql'
 
 }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=neroplan

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: neroplan
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/neroplan
+    username:
+    password:
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    show-sql: true
+
+server:
+  port: 8080


### PR DESCRIPTION
---
name: 오지현
about: 빌드오류
title:  postgresql 설정을 추가하고 DB를 설정하여 빌드 오류를 해결
labels: bug
assignees: 오지현
---

## 📌 작업 내용
- DB 설정과 postgresql 의존성을 추가하여 빌드 오류를 해결합니다.

## 🔍 주요 변경 사항
- build.gradle에 postgresql 의존성 추가
- application.properties 파일을 application.yml 파일로 변경 (동일 기능)

## 🧪 테스트 결과
- [x] 직접 실행하여 정상 동작 확인함
- [ ] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #17 

## ✅ 체크리스트
- [x] 빌드/테스트 정상 작동 확인
- [x] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [x] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- .env 파일은 아직 작성하지 않았습니다
- 현재 application.yml 파일에는 username과 password가 빈 칸으로 표시되어 있습니다. 개인 설정을 채우시고, neroplan DB table을 만든 뒤 실행하시면 빌드 오류가 나지 않습니다.