### PR TITLE
[FEAT] 전체 표준 응답 체계 ApiResponse, ErrorStatus 등 생성

### DIFF
--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/ApiResponse.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/ApiResponse.java
@@ -1,0 +1,44 @@
+package com.neroplan.backendPlan.global.apiPayload;
+
+
+import com.neroplan.backendPlan.global.apiPayload.code.BaseCode;
+import com.neroplan.backendPlan.global.apiPayload.code.status.SuccessStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({
+        "isSuccess",
+        "code",
+        "message",
+        "result"
+})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공 시 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    // 실패 시 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(true, code, message, data);
+    }
+}

--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/BaseCode.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/BaseCode.java
@@ -1,0 +1,9 @@
+package com.neroplan.backendPlan.global.apiPayload.code;
+
+import com.neroplan.backendPlan.global.apiPayload.code.errorDto.ReasonDto;
+
+public interface BaseCode {
+    public ReasonDto getReason();
+
+    public ReasonDto getReasonHttpStatus();
+}

--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/BaseErrorCode.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,11 @@
+package com.neroplan.backendPlan.global.apiPayload.code;
+
+import com.neroplan.backendPlan.global.apiPayload.code.errorDto.ErrorReasonDto;
+
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDto getReason();
+
+    public ErrorReasonDto getReasonHttpStatus();
+}

--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/errorDto/ErrorReasonDto.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/errorDto/ErrorReasonDto.java
@@ -1,0 +1,18 @@
+package com.neroplan.backendPlan.global.apiPayload.code.errorDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorReasonDto {
+    private String message;
+    private String code;
+    private Boolean isSuccess;
+    private HttpStatus httpStatus;
+}

--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/errorDto/ReasonDto.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/errorDto/ReasonDto.java
@@ -1,0 +1,18 @@
+package com.neroplan.backendPlan.global.apiPayload.code.errorDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReasonDto {
+    private String message;
+    private String code;
+    private Boolean isSuccess;
+    private HttpStatus httpStatus;
+}

--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/status/ErrorStatus.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,83 @@
+package com.neroplan.backendPlan.global.apiPayload.code.status;
+
+import com.neroplan.backendPlan.global.apiPayload.code.BaseCode;
+import com.neroplan.backendPlan.global.apiPayload.code.BaseErrorCode;
+
+import com.neroplan.backendPlan.global.apiPayload.code.errorDto.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 500 Internal Server Error
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "데이터베이스 에러, 관리자에게 문의 바랍니다."),
+    _FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "파일 업로드에 실패하였습니다."),
+    _FILE_DOWNLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "파일 다운로드에 실패하였습니다."),
+    _FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "파일 삭제에 실패하였습니다."),
+
+    // 400 Bad Request
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "400", "잘못된 요청입니다."),
+    _MAIL_ERROR(HttpStatus.BAD_REQUEST, "400", "인증 이메일 전송에 실패하였습니다."),
+    _DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "400", "중복된 이메일입니다."),
+    _DUPLICATED_LOGIN_ID(HttpStatus.BAD_REQUEST, "400", "중복된 로그인 ID입니다."),
+    _NON_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "400", "존재하지 않는 이메일입니다."),
+    _BAD_PASSWORD(HttpStatus.BAD_REQUEST, "400", "잘못된 패스워드입니다."),
+    _PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "400", "패스워드가 일치하지 않습니다."),
+    _IMAGE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "400", "이미지 업로드에 실패하였습니다."),
+    _IMAGE_DELETE_FAIL(HttpStatus.BAD_REQUEST, "400", "이미지 삭제에 실패하였습니다."),
+    _IMAGE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "400", "지원하지 않는 이미지 형식입니다. (jpg, jpeg, png, gif)"),
+    _USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "400", "해당 유저와 일치하지 않습니다."),
+    _USER_AlREADY_REGISTERED(HttpStatus.BAD_REQUEST, "400", "이미 등록된 사용자입니다."),
+
+    // 401 Unauthorized
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "인증이 필요합니다."),
+    _TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401", "해당 토큰이 만료되었습니다."),
+    _TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "401", "해당 토큰이 유효하지 않습니다."),
+    _MUST_BE_LEADER_TO_DO(HttpStatus.UNAUTHORIZED, "401", "해당 작업을 수행할 권한이 없습니다."),
+    _USER_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "해당 유저는 인증되지 않았습니다."),
+
+
+    // 403 Forbidden
+    _FORBIDDEN_PASSWORD(HttpStatus.FORBIDDEN, "403", "불가능한 패스워드입니다. 패스워드는 영어, 숫자 8~13글자만 가능합니다."),
+
+
+    // 404 Not Found
+    _TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 토큰을 찾을 수 없습니다."),
+    _USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 유저를 찾을 수 없습니다."),
+
+    // (Optional) 선택 추가 가능
+    _METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "405", "허용되지 않은 메서드입니다."),
+    _UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "415", "지원하지 않는 미디어 타입입니다."),
+    _TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "429", "요청이 너무 많습니다. 잠시 후 다시 시도하세요."),
+    _SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "503", "서비스를 사용할 수 없습니다. 점검 중일 수 있습니다.")
+
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/status/SuccessStatus.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,43 @@
+package com.neroplan.backendPlan.global.apiPayload.code.status;
+
+import com.neroplan.backendPlan.global.apiPayload.code.BaseCode;
+import com.neroplan.backendPlan.global.apiPayload.code.BaseErrorCode;
+
+import com.neroplan.backendPlan.global.apiPayload.code.errorDto.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    _CREATED(HttpStatus.CREATED, "COMMON201", "생성되었습니다."),
+    _AuthorIZED(HttpStatus.OK, "COMMON202", "인증되었습니다."),;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason(){
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build()
+                ;
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus(){
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- 전체 표준 응답 체계 global 폴더 및 파일 생성
- env 파일은 아직 수정 안했습니다

## 🔍 주요 변경 사항
- ErrorStatus : 에러 종류 목록
- SuccessStatus : 성공 종류 목록
- BaseErrorCode/BaseCode: 상태 enum들이 따라야 할 공통 규약
- ErrorReasonDto/ReasonDto : 응답용으로 가공한 Dto
- ApiResponse : 최종 JSON 응답 형식

- GeneralException : ErrorStatus를 담아 던지는 커스텀 예외 (아직 없음) - 예정
- ExceptionAdvice : 모든 예외를 한 곳에서 받아 응답으로 바꿈 (아직 없음) - 예정

## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [ ] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #32 

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- backendPlan에만 추가했는데, 이걸 공통 util로 빼서 모든 폴더(backendUser 등)에서 가져다가 쓰게끔 설계할지 고민입니다
