### PR TITLE
[FIX] api payload 반영 및 uri 누락 수정

### DIFF
--- a/backendPlan/src/main/java/com/neroplan/backendPlan/domain/plan/controller/PlanController.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/domain/plan/controller/PlanController.java
@@ -5,6 +5,7 @@ import com.neroplan.backendPlan.domain.plan.dto.CreatePlanResponseDto;
 import com.neroplan.backendPlan.domain.plan.dto.GetPlanResponseDto;
 import com.neroplan.backendPlan.domain.plan.dto.UpdatePlanRequestDto;
 import com.neroplan.backendPlan.domain.plan.service.PlanService;
+import com.neroplan.backendPlan.global.apiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,41 +14,41 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("")
+@RequestMapping("/api/v1/plans")
 @RequiredArgsConstructor
 public class PlanController {
     private final PlanService planService;
 
     // 1. 플랜 생성
     @PostMapping
-    public ResponseEntity<CreatePlanResponseDto> createPlan(@RequestBody CreatePlanRequestDto requestDto) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(planService.createPlan(requestDto));
+    public ApiResponse<CreatePlanResponseDto> createPlan(@RequestBody CreatePlanRequestDto requestDto) {
+        return ApiResponse.onSuccess(planService.createPlan(requestDto));
     }
 
-    // 2. 플랜별 단건 조회
+    // 2. 플랜별 단건 조회 - api 명세에 없으나 단건 조회가 필요한 경우 사용
     @GetMapping("/{planId}")
-    public ResponseEntity<GetPlanResponseDto> getPlan(@PathVariable Long planId) {
-        return ResponseEntity.ok(planService.getPlan(planId));
+    public ApiResponse<GetPlanResponseDto> getPlan(@PathVariable Long planId) {
+        return ApiResponse.onSuccess(planService.getPlan(planId));
     }
 
-    // 3. 유저별 전체 조회
+    // 3. 유저별 전체 조회 - date 파라미터를 붙일지 고민하고 수정 필요
     @GetMapping
-    public ResponseEntity<List<GetPlanResponseDto>> getPlansByUser(@RequestParam Long userId) {
-        return ResponseEntity.ok(planService.getPlansByUserId(userId));
+    public ApiResponse<List<GetPlanResponseDto>> getPlansByUser(@RequestParam Long userId) {
+        return ApiResponse.onSuccess(planService.getPlansByUserId(userId));
     }
 
     // 4. 플랜 수정
     @PatchMapping("/{planId}")
-    public ResponseEntity<GetPlanResponseDto> updatePlan(
+    public ApiResponse<GetPlanResponseDto> updatePlan(
             @PathVariable Long planId,
             @RequestBody UpdatePlanRequestDto requestDto) {
-        return ResponseEntity.ok(planService.updatePlan(planId, requestDto));
+        return ApiResponse.onSuccess(planService.updatePlan(planId, requestDto));
     }
 
     // 5. 플랜 삭제
     @DeleteMapping("/{planId}")
-    public ResponseEntity<Void> deletePlan(@PathVariable Long planId) {
+    public ApiResponse<String> deletePlan(@PathVariable Long planId) {
         planService.deletePlan(planId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.onSuccess("성공적으로 삭제되었습니다.");
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
- plan crud의 controller uri 수정합니다

## 🔍 주요 변경 사항
- requestMapping을 ""로 비워둬서 발생한 문제입니다
- controller uri 추가했습니다
- plan crud 수정하는 김에 apiResponse 표현식 반영했습니다


## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [ ] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #39

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 플랜 전체 조회에서 파라미터로 userId와 추가로 어떤 쿼리파라미터를 보낼지 결정해야 합니다.
