### PR TITLE
[FEAT] 프론트, 백엔드 연결 작업

### DIFF
--- a/backendPlan/Dockerfile
+++ b/backendPlan/Dockerfile
@@ -2,11 +2,11 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
+# RUN gradle build -x test
 RUN gradle build -x test
-
 # runner
 # FROM openjdk
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
-COPY --from=builder /app/build/libs/neroplan-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=builder /app/build/libs/backendPlan-0.0.1-SNAPSHOT.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/backendPlan/src/main/java/com/neroplan/backendPlan/global/SecurityConfig.java
+++ b/backendPlan/src/main/java/com/neroplan/backendPlan/global/SecurityConfig.java
@@ -14,6 +14,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .formLogin(formLogin -> formLogin.disable())
                 .authorizeHttpRequests(authz -> authz
                         .anyRequest().permitAll()  // 모든 요청 허용 (테스트용)
                 );

--- a/backendPlan/src/main/resources/application.yml
+++ b/backendPlan/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: neroplan
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/neroplan
-    username:
-    password:
+    url: jdbc:postgresql://postgres:5432/neroplan
+    username: postgres
+    password: 1234
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -19,3 +19,7 @@ spring:
 
 server:
   port: 8080
+
+logging:
+    level:
+      org.springframework.web: DEBUG

--- a/compose.yml
+++ b/compose.yml
@@ -44,6 +44,7 @@ services:
     ports:
       - "4001:8080"
     restart: always
+
     
   postgres:
     image: postgres:17

--- a/compose.yml
+++ b/compose.yml
@@ -28,10 +28,21 @@ services:
       context: backendUser # 어디 경로의 도커파일 실행할지 알려주는 부분 -> 현재 경로의 도커파일!
     env_file:
       - .env
-    image : backend
+    image : backend-user
     container_name: backendUser
     ports:
       - "4000:8080"
+    restart: always
+  
+  backendPlan:
+    build:
+      context: backendPlan
+    env_file:
+      - .env
+    image: backend-plan
+    container_name: backendPlan
+    ports:
+      - "4001:8080"
     restart: always
     
   postgres:

--- a/frontend/my-app/src/api/api.ts
+++ b/frontend/my-app/src/api/api.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+import { getAccessToken } from "./auth";
+
+const api = axios.create({
+  baseURL: "http://localhost:8080",
+});
+
+api.interceptors.request.use((config) => {
+  const token = getAccessToken();
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  return config;
+});
+
+export default api; 

--- a/frontend/my-app/src/api/auth.ts
+++ b/frontend/my-app/src/api/auth.ts
@@ -1,0 +1,8 @@
+
+export const saveAccessToken = (token: string) => {
+  localStorage.setItem("accessToken", token);
+};
+
+export const getAccessToken = () => {
+  return localStorage.getItem("accessToken");
+};

--- a/frontend/my-app/src/api/plan.ts
+++ b/frontend/my-app/src/api/plan.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+
+const API_URL = "http://localhost:8080/api/v1";   // 백엔드 주소
+
+export const createPlan = async (content: string) => {
+    const response = await axios.post(`${API_URL}/plans`, {
+        content,
+        priority: 1
+    });
+
+    return response.data;
+};

--- a/frontend/my-app/src/components/common/PlanInput.tsx
+++ b/frontend/my-app/src/components/common/PlanInput.tsx
@@ -1,6 +1,10 @@
 // components/common/PlanInput.tsx
+import { useState } from "react";
+import { createPlan } from "../../api/plan"; // 실제 위치에 맞게 경로 수정
 
 export default function PlanInput() {
+    const [plan, setPlan] = useState("");
+
     return (
         <div className="bg-white rounded-3xl p-6 shadow-sm">
             <h2 className="text-xl font-bold text-center mb-3">
@@ -12,6 +16,8 @@ export default function PlanInput() {
            <div className="space-y-3">
                 <input
                     type="text"
+                    value={plan}
+                    onChange={(e) => setPlan(e.target.value)}
                     placeholder="계획을 입력하세요"
                     className="
                         w-full
@@ -22,8 +28,12 @@ export default function PlanInput() {
                         outline-none
                     "
                 />
-            
                 <button
+                    onClick={() => {
+                        // 여기에 계획을 제출하는 로직을 추가하세요.
+                        console.log("제출된 계획:", plan);
+                        createPlan(plan);
+                    }}
                     className="
                         w-full
                         border

--- a/frontend/my-app/src/pages/PlanPage.tsx
+++ b/frontend/my-app/src/pages/PlanPage.tsx
@@ -1,10 +1,31 @@
 // pages/PlanPage.tsx
 
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import PlanCard from "../components/common/PlanCard";
 import PlanInput from "../components/common/PlanInput";
 import AnalyzeButton from "../components/PlanPage/button";
+import { saveAccessToken } from "../api/auth";
 
 export default function PlanPage() {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        const accessToken = params.get("accessToken");
+
+        if (accessToken) {
+            saveAccessToken(accessToken);
+
+            params.delete("accessToken");
+            const nextSearch = params.toString();
+            const nextPath = `${location.pathname}${nextSearch ? `?${nextSearch}` : ""}`;
+
+            navigate(nextPath, { replace: true });
+        }
+    }, [location.pathname, location.search, navigate]);
+
     return (
             <div className="space-y-8">
 

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -3,7 +3,24 @@ server {
     listen  [::]:80; #위의 포트랑 일치해야하고 docker run을 했을 때 서버 포트와 일치해야한다.
     server_name  localhost;
 
-    #access_log  /var/log/nginx/host.access.log  main;
+     # API 요청은 Spring Boot로 전달
+    location /api/v1/plans {
+        proxy_pass http://backendPlan:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/v1/users {
+        proxy_pass http://backendUser:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
     location / { #웹주소에 따라 어떤 html파일을 사용자에게 보여줄 것인지 설정하는 부분
         proxy_pass http://frontend:80;
@@ -18,26 +35,4 @@ server {
         root   /usr/share/nginx/html;
     }
 
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }


### PR DESCRIPTION

## 📌 작업 내용
- 프론트와 백엔드 연결 작업을 했습니다.
- 백엔드 spring security 설정을 우선 모든 요청에 대해 허락하도록 변경했습니다.
- plan을 생성하면 백엔드에 plan create 요청을 전송하여 정상 동작하는 것을 확인했습니다.
- 하지만 plan을 불러오는 DTO가 plan의 모든 어트리뷰트를 필요로 해 분석을 돌리지 않은 plan을 불러오는 DTO가 추가로 필요한 것을 확인하였습니다.

## 🔍 주요 변경 사항
- 프론트에서 백엔드 함수 요청
- backendPlan spring security 설정 변경(모든 요청 허가)

## 🧪 테스트 결과
- [x] 직접 실행하여 정상 동작 확인함
- [x] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #34 

## ✅ 체크리스트
- [x] 빌드/테스트 정상 작동 확인
- [x] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [x] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 
